### PR TITLE
chore: upgrade glasskube to v0.17.0

### DIFF
--- a/bootstrap/glasskube/glasskube.yaml
+++ b/bootstrap/glasskube/glasskube.yaml
@@ -9940,7 +9940,7 @@ spec:
         - --leader-elect
         command:
         - /package-operator
-        image: ghcr.io/glasskube/package-operator:v0.16.0
+        image: ghcr.io/glasskube/package-operator:v0.17.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/bootstrap/glasskube/glasskube.yaml
+++ b/bootstrap/glasskube/glasskube.yaml
@@ -8474,6 +8474,11 @@ spec:
                             If at least one such a resource exists, the namespace is created implicitly.
                           type: string
                         url:
+                          description: |-
+                            Url is the location of the manifest.
+                            Typically, this should be a full https URL, but local paths are also supporeted.
+                            If this field is set to a local path (e.g. a relative path like "./manifest.yaml" or just "manifest.yaml") it
+                            will be resolved relative to the packages "package.yaml" file.
                           type: string
                       required:
                       - url
@@ -8602,6 +8607,8 @@ spec:
                 required:
                 - name
                 type: object
+              resolvedUrl:
+                type: string
               version:
                 type: string
             type: object
@@ -10020,7 +10027,7 @@ spec:
           containers:
           - command:
             - /cert-manager
-            image: ghcr.io/glasskube/package-operator:v0.16.0
+            image: ghcr.io/glasskube/package-operator:v0.17.0
             name: manager
             resources:
               limits:
@@ -10053,7 +10060,7 @@ spec:
       containers:
       - command:
         - /cert-manager
-        image: ghcr.io/glasskube/package-operator:v0.16.0
+        image: ghcr.io/glasskube/package-operator:v0.17.0
         name: manager
         resources:
           limits:


### PR DESCRIPTION
I know this isn't a scalable solution but for the time being I'm updating the operator to match the latest version release.