### PR TITLE
feat: migrate to glasskube renovate manager, enable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,16 +3,11 @@
   "extends": [
     "config:recommended"
   ],
-  "regexManagers": [
-    {
-        "fileMatch": [
-          ".+\\.(yaml)|(yml)$"
-        ],
-        "matchStrings": [
-          "packageInfo:.*\n.*name: (?<depName>.*)\n.*\n.*version: (?<currentValue>.*)"
-        ],
-        "datasourceTemplate": "glasskube-packages",
-        "versioningTemplate": "glasskube"
-    }
-  ]
+  "glasskube": {
+    "fileMatch": [
+      "^packages/.*\\.yaml$"
+    ]
+  },
+  "automerge": true,
+  "ignoreTests": true
 }


### PR DESCRIPTION
As packages are already approved via https://github.com/glasskube/packages we don't need to approve them again here.